### PR TITLE
Fix SQL capitalization problems

### DIFF
--- a/admin/classes/domain/Document.php
+++ b/admin/classes/domain/Document.php
@@ -29,10 +29,10 @@ class Document extends DatabaseObject {
 
 		$query = "SELECT date_format(MAX(signatureDate), '%m/%d/%Y') lastSignatureDate
 					FROM Signature S, Document D
-					WHERE D.documentId = S.DocumentId
+					WHERE D.documentID = S.DocumentID
 					AND (D.expirationDate is null || D.expirationDate = '0000-00-00')
 					AND D.documentID = " . $this->documentID . "
-					GROUP BY S.documentId
+					GROUP BY S.documentID
 					ORDER BY 1;";
 
 		$result = $this->db->processQuery($query, 'assoc');

--- a/admin/classes/domain/Expression.php
+++ b/admin/classes/domain/Expression.php
@@ -27,7 +27,7 @@ class Expression extends DatabaseObject {
 	//returns array of qualifier objects
 	public function getQualifiers(){
 
-		$query = "SELECT Qualifier.* FROM Qualifier, ExpressionQualifierProfile EQP where EQP.QualifierID = Qualifier.QualifierID AND expressionID = '" . $this->expressionID . "'";
+		$query = "SELECT Qualifier.* FROM Qualifier, ExpressionQualifierProfile EQP where EQP.qualifierID = Qualifier.qualifierID AND expressionID = '" . $this->expressionID . "'";
 
 		$result = $this->db->processQuery($query, 'assoc');
 
@@ -84,10 +84,10 @@ class Expression extends DatabaseObject {
 
 		$query = "SELECT date_format(MAX(updateDate), '%m/%d/%Y') lastUpdateDate FROM (
 					SELECT MAX(lastUpdateDate) updateDate
-						FROM Expression WHERE ExpressionId='" . $this->expressionID . "'
+						FROM Expression WHERE expressionID='" . $this->expressionID . "'
 					UNION
 					SELECT MAX(lastUpdateDate) updateDate
-						FROM ExpressionNote WHERE ExpressionId='" . $this->expressionID . "') allDates;";
+						FROM ExpressionNote WHERE expressionID='" . $this->expressionID . "') allDates;";
 
 		$result = $this->db->processQuery($query, 'assoc');
 

--- a/admin/classes/domain/ExpressionType.php
+++ b/admin/classes/domain/ExpressionType.php
@@ -58,7 +58,7 @@ class ExpressionType extends DatabaseObject {
 
 		$query = ("SELECT E.expressionID
 					FROM Document D, SFXProvider SP, Expression E
-					WHERE D.documentId = E.documentId
+					WHERE D.documentID = E.documentID
 					AND (D.expirationDate is null || D.expirationDate = '0000-00-00')
 					AND SP.documentID = D.documentID
 					AND E.productionUseInd='1'
@@ -95,7 +95,7 @@ class ExpressionType extends DatabaseObject {
 
 		$query = ("SELECT distinct E.expressionTypeID
 					FROM Document D, SFXProvider SP, Expression E, ExpressionType ET
-					WHERE D.documentId = E.documentId
+					WHERE D.documentID = E.documentID
 					AND (D.expirationDate is null || D.expirationDate = '0000-00-00')
 					AND SP.documentID = D.documentID
 					AND E.productionUseInd='1'


### PR DESCRIPTION
MySQL appears to be case insensitive, so capitalization doesn't matter in this case. BUT this is not true of every database platforms, so if we hope to support other platforms someday, this case needs to be fixed. Also, inconsistent capitalization makes the code confusing and may lead to bugs.
